### PR TITLE
Translate security-authorization-simple in Korean

### DIFF
--- a/aspnetcore/security/authorization/simple.md
+++ b/aspnetcore/security/authorization/simple.md
@@ -17,64 +17,64 @@ ms.translationtype: MT
 ms.contentlocale: ko-KR
 ms.lasthandoff: 08/11/2017
 ---
-# <a name="simple-authorization"></a>단순 권한 부여
+# 단순 권한 부여
 
 <a name=security-authorization-simple></a>
 
-MVC에서 권한 부여를 통해 제어 됩니다는 `AuthorizeAttribute` 특성 및 해당 다양 한 매개 변수입니다. 가장 간단한 적용에 `AuthorizeAttribute` 특성는 컨트롤러나 작업 제한에 대 한 액세스는 컨트롤러 또는 모든 인증 된 사용자 동작을 합니다.
+MVC에서 권한부여는 `AuthorizeAttribute` 특성과 이 특성의 여러 매개 변수를 통해 제어됩니다. 가장 단순한 경우, 컨트롤러나 동작에 `AuthorizeAttribute` 특성을 적용하면 인증된 사용자만 해당 컨트롤러나 동작에 접근할 수 있도록 제한됩니다.
 
-다음 코드에 대 한 액세스를 제한 하는 예를 들어는 `AccountController` 모든 인증 된 사용자입니다.
+예를 들어, 다음 코드는 `AccountController` 접근을 인증된 사용자로 제한합니다.
 
 ```csharp
 [Authorize]
-   public class AccountController : Controller
-   {
-       public ActionResult Login()
-       {
-       }
+public class AccountController : Controller
+{
+    public ActionResult Login()
+    {
+    }
 
-       public ActionResult Logout()
-       {
-       }
-   }
-   ```
+    public ActionResult Logout()
+    {
+    }
+}
+```
 
-단순히 컨트롤러 아니라 작업에 권한 부여를 적용 하려면 적용는 `AuthorizeAttribute` 특성을 작업 자체입니다.
+만약 권한부여를 컨트롤러가 아니라 동작에 적용하고 싶다면 단순하게 동작 자체에 `AuthorizeAttribute` 특성을 적용하세요.
 
 ```csharp
 public class AccountController : Controller
-   {
-       public ActionResult Login()
-       {
-       }
+{
+    public ActionResult Login()
+    {
+    }
 
-       [Authorize]
-       public ActionResult Logout()
-       {
-       }
-   }
-   ```
+    [Authorize]
+    public ActionResult Logout()
+    {
+    }
+}
+```
 
-이제 인증 된 사용자만 로그 아웃 함수에 액세스할 수 있습니다.
+이제 인증된 사용자만 `Logout` 함수에 접근할 수 있습니다.
 
-사용할 수도 있습니다는 `AllowAnonymousAttribute` ; 개별 작업에 대 한 인증 되지 않은 사용자가 액세스할 수 있도록 특성 예
+개별 동작에 인증되지 않은 사용자의 접근을 허용하기 위해 `AllowAnonymousAttribute` 특성을 사용할 수도 있습니다. 예를 들어:
 
 ```csharp
 [Authorize]
-   public class AccountController : Controller
-   {
-       [AllowAnonymous]
-       public ActionResult Login()
-       {
-       }
+public class AccountController : Controller
+{
+    [AllowAnonymous]
+    public ActionResult Login()
+    {
+    }
 
-       public ActionResult Logout()
-       {
-       }
-   }
-   ```
+    public ActionResult Logout()
+    {
+    }
+}
+```
 
-이렇게 하면 인증 된 사용자만는 `AccountController`를 제외 하 고는 `Login` / 익명 인증 된 인증 되지 않은 상태에 관계 없이 모든 사용자가 액세스할 수 있는 작업입니다.
+이렇게 하면 인증된 사용자만 `AccountController`에 허용되는데 예외적으로 `Login` 동작은 인증 여부에 관계없이 모두가 접근할 수 있습니다.
 
 >[!WARNING]
-> `[AllowAnonymous]`모든 권한 부여 문을 무시합니다. 결합 되어 감사가 만들어집니다를 적용 하는 경우 `[AllowAnonymous]` 임의의 `[Authorize]` 특성 설정한 다음 권한 부여 특성은 항상 무시 됩니다. 예를 적용 하는 경우 `[AllowAnonymous]` 모든 컨트롤러 수준 `[Authorize]` 내 모든 작업 또는 동일한 컨트롤러에서 특성이 무시 됩니다.
+> `[AllowAnonymous]`는 모든 권한부여 구문을 무시합니다. 만약 `[AllowAnonymous]`와 어떤 `[Authorize]` 특성을 조합해 적용하면 `[Authorize]` 특성은 항상 무시됩니다. 예를 들어 `[AllowAnonymous]`를 컨트롤러 수준에 적용하면 해당 컨트롤러와 내부 동작의 모든 `[Authorize]` 특성은 무시됩니다.


### PR DESCRIPTION
Improve the machine translated Korean content.